### PR TITLE
allow dragmove to the settings screen

### DIFF
--- a/StarryEyes/Views/WindowParts/Flips/SettingFlip.xaml.cs
+++ b/StarryEyes/Views/WindowParts/Flips/SettingFlip.xaml.cs
@@ -24,5 +24,11 @@ namespace StarryEyes.Views.WindowParts.Flips
         {
             InitializeComponent();
         }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            if(e.GetPosition(null).Y < 48)
+                Window.GetWindow(this).DragMove();
+        }
     }
 }


### PR DESCRIPTION
settingsを開いてる時にウィンドウの移動ができないので上端から48pxの範囲でDragMoveを可能にしてみました
移動できないのが仕様だったらリジェクトしてください
