### PR TITLE
スクリプトが実行できないのを修正

### DIFF
--- a/StarryEyes.Feather/Scripting/ScriptingManager.cs
+++ b/StarryEyes.Feather/Scripting/ScriptingManager.cs
@@ -31,7 +31,7 @@ namespace StarryEyes.Feather.Scripting
                     var ext = file.Extension.TrimStart('.').ToLower();
                     IScriptExecutor executor;
                     if (_executors.TryGetValue(ext, out executor))
-                        executor.ExecuteScript(ext);
+                        executor.ExecuteScript(file.FullName);
                 });
         }
     }


### PR DESCRIPTION
ExecuteScript の引数が拡張子になっていました。
