### PR TITLE
コンシューマーキーに余計な文字が入っていないかのチェック

### DIFF
--- a/StarryEyes/ViewModels/Dialogs/KeyOverrideViewModel.cs
+++ b/StarryEyes/ViewModels/Dialogs/KeyOverrideViewModel.cs
@@ -73,6 +73,32 @@ namespace StarryEyes.ViewModels.Dialogs
                     }));
                 return;
             }
+            if (!(System.Text.RegularExpressions.Regex.Match(OverrideConsumerKey, "^[a-zA-Z0-9]+$")).Success)
+            {
+                this.Messenger.Raise(new TaskDialogMessage(
+                    new TaskDialogOptions
+                    {
+                        Title = "キー設定エラー",
+                        MainIcon = VistaTaskDialogIcon.Error,
+                        MainInstruction = "Consumer Keyが間違っています。",
+                        Content = "入力されたConsumer Keyに使用できない文字が含まれています。入力したキーを確認してください。",
+                        CommonButtons = TaskDialogCommonButtons.Close
+                    }));
+                return;
+            }
+            if (!(System.Text.RegularExpressions.Regex.Match(OverrideConsumerSecret, "^[a-zA-Z0-9]+$")).Success)
+            {
+                this.Messenger.Raise(new TaskDialogMessage(
+                    new TaskDialogOptions
+                    {
+                        Title = "キー設定エラー",
+                        MainIcon = VistaTaskDialogIcon.Error,
+                        MainInstruction = "Consumer Secretが間違っています。",
+                        Content = "入力されたConsumer Secretに使用できない文字が含まれています。入力したキーを確認してください。",
+                        CommonButtons = TaskDialogCommonButtons.Close
+                    }));
+                return;
+            }
             if (IsKeyChecking) return;
             IsKeyChecking = true;
             var authorizer = new OAuthAuthorizer(OverrideConsumerKey, OverrideConsumerSecret);


### PR DESCRIPTION
コンシューマーキーの末尾に半角スペースが入っていてもアカウント登録が通ってしまい、そのままキーが保存されてしまうため、正常にアカウントが登録されているのにCould not authenticate youと言われてしまう。
![image](https://f.cloud.github.com/assets/971376/1702010/2628a28e-607c-11e3-86de-ce38f8d126e9.png)

とりあえず入力の時点で弾くようにしてみました
