### PR TITLE
Add user set literal in KQL

### DIFF
--- a/StarryEyes/Filters/Parsing/QueryCompiler.cs
+++ b/StarryEyes/Filters/Parsing/QueryCompiler.cs
@@ -363,6 +363,21 @@ namespace StarryEyes.Filters.Parsing
                 reader.AssertGet(TokenType.CloseBracket);
                 return new FilterBracket { Value = ret };
             }
+            if (reader.LookAhead().Type == TokenType.OpenSquareBracket)
+            {
+                reader.AssertGet(TokenType.OpenSquareBracket);
+                var values = new HashSet<ValueBase>();
+                while (reader.LookAhead().Type != TokenType.CloseSquareBracket)
+                {
+                    values.Add(GetValue(reader));
+                    if (reader.LookAhead().Type == TokenType.Comma)
+                    {
+                        reader.AssertGet(TokenType.Comma);
+                    }
+                }
+                reader.AssertGet(TokenType.CloseSquareBracket);
+                return new UserSet(values);
+            }
             return GetValue(reader);
         }
 

--- a/StarryEyes/Filters/Parsing/Token.cs
+++ b/StarryEyes/Filters/Parsing/Token.cs
@@ -45,6 +45,10 @@ namespace StarryEyes.Filters.Parsing
                     return "( [開き括弧]";
                 case TokenType.CloseBracket:
                     return ") [閉じ括弧]";
+                case TokenType.OpenSquareBracket:
+                    return "[ [開き角括弧]";
+                case TokenType.CloseSquareBracket:
+                    return "] [閉じ角括弧]";
                 case TokenType.OperatorPlus:
                     return "+ [和]";
                 case TokenType.OperatorMinus:
@@ -190,6 +194,14 @@ namespace StarryEyes.Filters.Parsing
         /// Close bracket, )
         /// </summary>
         CloseBracket,
+        /// <summary>
+        /// Open square bracket, (
+        /// </summary>
+        OpenSquareBracket,
+        /// <summary>
+        /// Close square bracket, ]
+        /// </summary>
+        CloseSquareBracket,
         /// <summary>
         /// Quoted string
         /// </summary>

--- a/StarryEyes/Filters/Parsing/Tokenizer.cs
+++ b/StarryEyes/Filters/Parsing/Tokenizer.cs
@@ -60,6 +60,12 @@ namespace StarryEyes.Filters.Parsing
                     case ')':
                         yield return new Token(TokenType.CloseBracket, strptr);
                         break;
+                    case '[':
+                        yield return new Token(TokenType.OpenSquareBracket, strptr);
+                        break;
+                    case ']':
+                        yield return new Token(TokenType.CloseSquareBracket, strptr);
+                        break;
                     case '+':
                         yield return new Token(TokenType.OperatorPlus, strptr);
                         break;
@@ -121,7 +127,7 @@ namespace StarryEyes.Filters.Parsing
                     default:
                         var begin = strptr;
                         // 何らかのトークン分割子に出会うまで空回し
-                        const string tokens = "&|<>()+-*/.,:=!\" \t\r\n";
+                        const string tokens = "&|<>()[]+-*/.,:=!\" \t\r\n";
                         do
                         {
                             if (tokens.Contains(query[strptr]))


### PR DESCRIPTION
## 変更点

現状:

```
from local where user = @alice | user = @bob | user = @charlie | user = #12345678
```

上のクエリを、こう書けるようにした:

```
from local where user in [@alice, @bob, @charlie, #12345678]
```

`user.following` を指定するのと同じように、普通に `WHERE … IN …` クエリに展開されているはず。
## 効果
- 複数ユーザを対象とする際に読みやすく、書きやすくなる
- numeric や string にはリテラルがあるのに set にリテラルがない不整合の解決。
- or で繋げるより SQL 長が抑えられ、性能が向上する [要出典]。
## その他
- 面倒なので `[` ～ `]` を区切るカンマ `,` は最後の一個が余計でも動くようにしてます (ex: `[ @foo, @bar, ]`)。
- 一応 (`from local` で) 期待する動作を満たすことをテスト済ですが、不十分かも。
- `text contains` とかでも set literal 使えるようにしたいけど、そもそも SQL 的に無理な気がしてきたので今回は見送り。
- トークン名で `(` `)` が `OpenBracket` `CloseBracket` となっていたが、`()` は parenthesis で `[]` が bracket なのが一般的かとは思われる…が、変更を最小限にするために今回は `[]` に SquareBracket の名称を当てました。問題があるなら別途変更ください。
