### PR TITLE
Fix an issue of duplicating # when searching hashtags

### DIFF
--- a/StarryEyes/ViewModels/Timelines/Statuses/StatusViewModel.cs
+++ b/StarryEyes/ViewModels/Timelines/Statuses/StatusViewModel.cs
@@ -1359,7 +1359,7 @@ namespace StarryEyes.ViewModels.Timelines.Statuses
                     SearchFlipModel.RequestSearch(param.Item2, SearchMode.UserScreenName);
                     break;
                 case LinkType.Hash:
-                    SearchFlipModel.RequestSearch("#" + param.Item2, SearchMode.Web);
+                    SearchFlipModel.RequestSearch(param.Item2, SearchMode.Web);
                     break;
                 case LinkType.Url:
                     BrowserHelper.Open(param.Item2);


### PR DESCRIPTION
In spite of containing a '#' in the link string, another # has been add.
Get rid of an unnecessary suffix. (fix #123)
