### PR TITLE
Change security protocol from SSL v3 to TLS v1.2

### DIFF
--- a/StarryEyes/AppInitializer.cs
+++ b/StarryEyes/AppInitializer.cs
@@ -249,7 +249,7 @@ namespace StarryEyes
             ServicePointManager.DefaultConnectionLimit = Int32.MaxValue; // Limit Break!
 
             // declare security protocol explicitly
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
         private static void InitializeSubsystemsBeforeSettingsLoaded()


### PR DESCRIPTION
https://twitter.com/twittersecurity/status/522190947782643712
SSL接続を拒否するようになったため、TLS 1.2で接続するように変更しました。
