### PR TITLE
Backstage UI Improvements

### DIFF
--- a/StarryEyes/Models/BackstageModel.cs
+++ b/StarryEyes/Models/BackstageModel.cs
@@ -80,7 +80,8 @@ namespace StarryEyes.Models
             if (tev == null) return;
             lock (_twitterEvents.SyncRoot)
             {
-                _twitterEvents.Insert(0, tev);
+                if(Setting.Accounts.Ids.Contains(tev.Source.Id) || Setting.Accounts.Ids.Contains(tev.TargetUser.Id))
+                    _twitterEvents.Insert(0, tev);
                 if (_twitterEvents.Count > TwitterEventMaxHoldCount)
                     _twitterEvents.RemoveAt(_twitterEvents.Count - 1);
             }

--- a/StarryEyes/Models/BackstageModel.cs
+++ b/StarryEyes/Models/BackstageModel.cs
@@ -80,7 +80,7 @@ namespace StarryEyes.Models
             if (tev == null) return;
             lock (_twitterEvents.SyncRoot)
             {
-                if(Setting.Accounts.Ids.Contains(tev.Source.Id) || Setting.Accounts.Ids.Contains(tev.TargetUser.Id))
+                if(tev.IsLocalUserInvolved)
                     _twitterEvents.Insert(0, tev);
                 if (_twitterEvents.Count > TwitterEventMaxHoldCount)
                     _twitterEvents.RemoveAt(_twitterEvents.Count - 1);

--- a/StarryEyes/Models/Backstages/TwitterEvents/TwitterEventBase.cs
+++ b/StarryEyes/Models/Backstages/TwitterEvents/TwitterEventBase.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Windows.Media;
 using StarryEyes.Anomaly.TwitterApi.DataModels;
+using StarryEyes.Settings;
 using StarryEyes.Views;
 
 namespace StarryEyes.Models.Backstages.TwitterEvents
@@ -30,6 +32,8 @@ namespace StarryEyes.Models.Backstages.TwitterEvents
         {
             get { return _targetStatus; }
         }
+
+        public bool IsLocalUserInvolved => Setting.Accounts.Ids.Contains(Source.Id) || Setting.Accounts.Ids.Contains(TargetUser.Id);
 
         public TwitterEventBase(TwitterUser source, TwitterUser target)
         {

--- a/StarryEyes/ViewModels/WindowParts/BackstageViewModel.cs
+++ b/StarryEyes/ViewModels/WindowParts/BackstageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using System.Windows.Threading;
 using Livet;
 using StarryEyes.Models;
 using StarryEyes.Models.Backstages;
+using StarryEyes.Models.Backstages.TwitterEvents;
 using StarryEyes.Settings;
 using StarryEyes.ViewModels.WindowParts.Backstages;
 using StarryEyes.Views.Utils;
@@ -148,7 +150,11 @@ namespace StarryEyes.ViewModels.WindowParts
                     ev = _waitingEvents.Dequeue();
                 }
                 CurrentEvent = new BackstageEventViewModel(ev);
-                ShowCurrentEvent = true;
+
+                var tev = ev as TwitterEventBase;
+                if (tev !=null && (Setting.Accounts.Ids.Contains(tev.Source.Id) || Setting.Accounts.Ids.Contains(tev.TargetUser.Id)))
+                    ShowCurrentEvent = true;
+
                 Thread.Sleep(Math.Max(Setting.EventDisplayMinimumMSec.Value, 100));
                 lock (_syncLock)
                 {

--- a/StarryEyes/ViewModels/WindowParts/BackstageViewModel.cs
+++ b/StarryEyes/ViewModels/WindowParts/BackstageViewModel.cs
@@ -152,7 +152,7 @@ namespace StarryEyes.ViewModels.WindowParts
                 CurrentEvent = new BackstageEventViewModel(ev);
 
                 var tev = ev as TwitterEventBase;
-                if (tev !=null && (Setting.Accounts.Ids.Contains(tev.Source.Id) || Setting.Accounts.Ids.Contains(tev.TargetUser.Id)))
+                if (tev != null && tev.IsLocalUserInvolved)
                     ShowCurrentEvent = true;
 
                 Thread.Sleep(Math.Max(Setting.EventDisplayMinimumMSec.Value, 100));

--- a/StarryEyes/ViewModels/WindowParts/Backstages/TwitterEventViewModel.cs
+++ b/StarryEyes/ViewModels/WindowParts/Backstages/TwitterEventViewModel.cs
@@ -18,9 +18,28 @@ namespace StarryEyes.ViewModels.WindowParts.Backstages
         public void OpenEventSourceUserProfile()
         {
             var ev = TwitterEvent;
-            if (ev == null || ev.Source == null) return;
+            if (ev?.Source == null) return;
             BackstageModel.RaiseCloseBackstage();
             SearchFlipModel.RequestSearch(ev.Source.ScreenName, SearchMode.UserScreenName);
+        }
+
+        public void OpenEventTargetStatus()
+        {
+            var ev = TwitterEvent;
+            if (ev?.TargetStatus == null) return;
+            BackstageModel.RaiseCloseBackstage();
+            SearchFlipModel.RequestSearch("?from conv:\"" + ev.TargetStatus.Id + "\"", SearchMode.Local);
+        }
+
+        public void OpenEventDetail()
+        {
+            var ev = TwitterEvent;
+
+            if (ev?.TargetStatus != null)
+                OpenEventTargetStatus();
+
+            if (ev?.Source != null)
+                OpenEventSourceUserProfile();
         }
     }
 }

--- a/StarryEyes/Views/WindowParts/Backstage.xaml
+++ b/StarryEyes/Views/WindowParts/Backstage.xaml
@@ -151,7 +151,7 @@
                                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                                     <i:Interaction.Triggers>
                                         <i:EventTrigger EventName="MouseLeftButtonDown">
-                                            <ei:CallMethodAction MethodName="OpenEventSourceUserProfile" TargetObject="{Binding}" />
+                                            <ei:CallMethodAction MethodName="OpenEventDetail" TargetObject="{Binding}" />
                                         </i:EventTrigger>
                                     </i:Interaction.Triggers>
                                     <Image Width="16"


### PR DESCRIPTION
Modified majorly two things:
- Filtered out others' activities from `Backstage` View. Reasons:
  1. The bottom status bar becomes too spammy and flashy. 
  2. The Backstage list gets mixed up, thought it would be better if the list functioned just as a notification history rather than enumerating all received events. (planning to create "Activities" tab feature)
  
- Clicking fav/RT event takes users to the `TargetStatus`. Reasons:
  1. Looking for the `Source(TwitterUser)` from the `TargetStatus` is easy but the opposite task is a hassle (isn't it?). Therefore the `TargetStatus` should be opened.
  2. For the sake of consistency with the official app.