### PR TITLE
Use tweet_mode (extended) parameter

### DIFF
--- a/StarryEyes.Anomaly/TwitterApi/DataModels/TwitterConfiguration.cs
+++ b/StarryEyes.Anomaly/TwitterApi/DataModels/TwitterConfiguration.cs
@@ -7,7 +7,7 @@ namespace StarryEyes.Anomaly.TwitterApi.DataModels
 
         public TwitterConfiguration(dynamic json)
         {
-            this.CharactersReservedPerMedia = (int)json.characters_reserved_per_media;
+            this.CharactersReservedPerMedia = 0; // media url -> 0 (extended_tweet)
             this.PhotoSizeLimit = (int)json.photo_size_limit;
             this.ShortUrlLength = (int)json.short_url_length;
             this.ShortUrlLengthHttps = (int)json.short_url_length_https;

--- a/StarryEyes.Anomaly/TwitterApi/Rest/Favorites.cs
+++ b/StarryEyes.Anomaly/TwitterApi/Rest/Favorites.cs
@@ -10,24 +10,26 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
     {
         public static Task<IEnumerable<TwitterStatus>> GetFavoritesAsync(
             this IOAuthCredential credential, long userId,
-            int? count = null, long? sinceId = null, long? maxId = null)
+            int? count = null, long? sinceId = null, long? maxId = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
-            return GetFavoritesCoreAsync(credential, userId, null, count, sinceId, maxId);
+            return GetFavoritesCoreAsync(credential, userId, null, count, sinceId, maxId, extendedTweet);
         }
 
         public static Task<IEnumerable<TwitterStatus>> GetFavoritesAsync(
             this IOAuthCredential credential, string screenName,
-            int? count = null, long? sinceId = null, long? maxId = null)
+            int? count = null, long? sinceId = null, long? maxId = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             if (screenName == null) throw new ArgumentNullException("screenName");
-            return GetFavoritesCoreAsync(credential, null, screenName, count, sinceId, maxId);
+            return GetFavoritesCoreAsync(credential, null, screenName, count, sinceId, maxId, extendedTweet);
         }
 
         private static async Task<IEnumerable<TwitterStatus>> GetFavoritesCoreAsync(
             IOAuthCredential credential, long? userId, string screenName,
-            int? count, long? sinceId, long? maxId)
+            int? count, long? sinceId, long? maxId, bool extendedTweet)
         {
             var param = new Dictionary<string, object>
             {
@@ -36,6 +38,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"count", count},
                 {"since_id", sinceId},
                 {"max_id", maxId},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("favorites/list.json", param));
@@ -43,12 +46,13 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         }
 
         public static async Task<TwitterStatus> CreateFavoriteAsync(
-            this IOAuthCredential credential, long id)
+            this IOAuthCredential credential, long id, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             var param = new Dictionary<string, object>
             {
-                {"id", id}
+                {"id", id},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForPost();
             var client = credential.CreateOAuthClient();
             var response = await client.PostAsync(new ApiAccess("favorites/create.json"), param);
@@ -56,12 +60,13 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         }
 
         public static async Task<TwitterStatus> DestroyFavoriteAsync(
-            this IOAuthCredential credential, long id)
+            this IOAuthCredential credential, long id, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             var param = new Dictionary<string, object>
             {
-                {"id", id}
+                {"id", id},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForPost();
             var client = credential.CreateOAuthClient();
             var response = await client.PostAsync(new ApiAccess("favorites/destroy.json"), param);

--- a/StarryEyes.Anomaly/TwitterApi/Rest/Lists.cs
+++ b/StarryEyes.Anomaly/TwitterApi/Rest/Lists.cs
@@ -87,37 +87,40 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
 
         public static Task<IEnumerable<TwitterStatus>> GetListTimelineAsync(
             this IOAuthCredential credential, long listId,
-            long? sinceId = null, long? maxId = null, int? count = null, bool? includeRts = null)
+            long? sinceId = null, long? maxId = null, int? count = null, bool? includeRts = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             return GetListTimelineCoreAsync(
-                credential, listId, null, null, null, sinceId, maxId, count, includeRts);
+                credential, listId, null, null, null, sinceId, maxId, count, includeRts, extendedTweet);
         }
 
         public static Task<IEnumerable<TwitterStatus>> GetListTimelineAsync(
             this IOAuthCredential credential, string slug, long userId,
-            long? sinceId = null, long? maxId = null, int? count = null, bool? includeRts = null)
+            long? sinceId = null, long? maxId = null, int? count = null, bool? includeRts = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             if (slug == null) throw new ArgumentNullException("slug");
             return GetListTimelineCoreAsync(
-                credential, null, slug, userId, null, sinceId, maxId, count, includeRts);
+                credential, null, slug, userId, null, sinceId, maxId, count, includeRts, extendedTweet);
         }
 
         public static Task<IEnumerable<TwitterStatus>> GetListTimelineAsync(
             this IOAuthCredential credential, string slug, string screenName,
-            long? sinceId = null, long? maxId = null, int? count = null, bool? includeRts = null)
+            long? sinceId = null, long? maxId = null, int? count = null, bool? includeRts = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             if (slug == null) throw new ArgumentNullException("slug");
             if (screenName == null) throw new ArgumentNullException("screenName");
             return GetListTimelineCoreAsync(
-                credential, null, slug, null, screenName, sinceId, maxId, count, includeRts);
+                credential, null, slug, null, screenName, sinceId, maxId, count, includeRts, extendedTweet);
         }
 
         public static async Task<IEnumerable<TwitterStatus>> GetListTimelineCoreAsync(
             IOAuthCredential credential, long? listId, string slug, long? userId, string screenName,
-            long? sinceId, long? maxId, int? count, bool? includeRts)
+            long? sinceId, long? maxId, int? count, bool? includeRts, bool extendedTweet)
         {
             var param = new Dictionary<string, object>()
             {
@@ -129,6 +132,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"max_id", maxId},
                 {"count", count},
                 {"include_rts", includeRts},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("lists/statuses.json", param));

--- a/StarryEyes.Anomaly/TwitterApi/Rest/Searching.cs
+++ b/StarryEyes.Anomaly/TwitterApi/Rest/Searching.cs
@@ -15,7 +15,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
             string geoCode = null, string lang = null, string locale = null,
             SearchResultType resultType = SearchResultType.Mixed,
             int? count = null, DateTime? untilDate = null,
-            long? sinceId = null, long? maxId = null)
+            long? sinceId = null, long? maxId = null, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             if (query == null) throw new ArgumentNullException("query");
@@ -30,6 +30,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"until", untilDate != null ? untilDate.Value.ToString("yyyy-MM-dd") : null},
                 {"since_id", sinceId},
                 {"max_id", maxId},
+                {"tweet_mode", extendedTweet ? "extended" : null }
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("search/tweets.json", param));

--- a/StarryEyes.Anomaly/TwitterApi/Rest/Timelines.cs
+++ b/StarryEyes.Anomaly/TwitterApi/Rest/Timelines.cs
@@ -10,14 +10,16 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
     {
         public static async Task<IEnumerable<TwitterStatus>> GetHomeTimelineAsync(
             this IOAuthCredential credential,
-            int? count = null, long? sinceId = null, long? maxId = null)
+            int? count = null, long? sinceId = null, long? maxId = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             var param = new Dictionary<string, object>
             {
                 {"count", count},
                 {"since_id", sinceId},
-                {"max_id", maxId}
+                {"max_id", maxId},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("statuses/home_timeline.json", param));
@@ -28,25 +30,28 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         public static Task<IEnumerable<TwitterStatus>> GetUserTimelineAsync(
             this IOAuthCredential credential, long userId,
             int? count = null, long? sinceId = null, long? maxId = null,
-            bool? excludeReplies = null, bool? includeRetweets = null)
+            bool? excludeReplies = null, bool? includeRetweets = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
-            return GetUserTimelineCoreAsync(credential, userId, null, count, sinceId, maxId, excludeReplies, includeRetweets);
+            return GetUserTimelineCoreAsync(credential, userId, null, count, sinceId, maxId, excludeReplies, includeRetweets, extendedTweet);
         }
 
         public static Task<IEnumerable<TwitterStatus>> GetUserTimelineAsync(
             this IOAuthCredential credential, string screenName,
             int? count = null, long? sinceId = null, long? maxId = null,
-            bool? excludeReplies = null, bool? includeRetweets = null)
+            bool? excludeReplies = null, bool? includeRetweets = null,
+            bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             if (screenName == null) throw new ArgumentNullException("screenName");
-            return GetUserTimelineCoreAsync(credential, null, screenName, count, sinceId, maxId, excludeReplies, includeRetweets);
+            return GetUserTimelineCoreAsync(credential, null, screenName, count, sinceId, maxId, excludeReplies, includeRetweets, extendedTweet);
         }
 
         private static async Task<IEnumerable<TwitterStatus>> GetUserTimelineCoreAsync(
             IOAuthCredential credential, long? userId, string screenName,
-            int? count, long? sinceId, long? maxId, bool? excludeReplies, bool? includeRetweets)
+            int? count, long? sinceId, long? maxId, bool? excludeReplies, bool? includeRetweets,
+            bool extendedTweet)
         {
             var param = new Dictionary<string, object>
             {
@@ -57,6 +62,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"count", count},
                 {"exclude_replies", excludeReplies},
                 {"include_rts", includeRetweets},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("statuses/user_timeline.json", param));
@@ -68,7 +74,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         public static async Task<IEnumerable<TwitterStatus>> GetMentionsAsync(
             this IOAuthCredential credential,
             int? count = null, long? sinceId = null, long? maxId = null,
-            bool? includeRetweets = null)
+            bool? includeRetweets = null, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             var param = new Dictionary<string, object>
@@ -77,6 +83,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"since_id", sinceId},
                 {"max_id", maxId},
                 {"include_rts", includeRetweets},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("statuses/mentions_timeline.json", param));
@@ -85,7 +92,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
 
         public static async Task<IEnumerable<TwitterStatus>> GetRetweetsOfMeAsync(
             this IOAuthCredential credential,
-            int? count = null, long? sinceId = null, long? maxId = null)
+            int? count = null, long? sinceId = null, long? maxId = null, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             var param = new Dictionary<string, object>
@@ -93,6 +100,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"count", count},
                 {"since_id", sinceId},
                 {"max_id", maxId},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("statuses/retweets_of_me.json", param));

--- a/StarryEyes.Anomaly/TwitterApi/Rest/Tweets.cs
+++ b/StarryEyes.Anomaly/TwitterApi/Rest/Tweets.cs
@@ -85,7 +85,7 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         public static async Task<TwitterStatus> UpdateAsync(
             this IOAuthCredential credential, string status, long? inReplyToStatusId = null,
             Tuple<double, double> geoLatLong = null, string placeId = null,
-            bool? displayCoordinates = null, long[] mediaIds = null)
+            bool? displayCoordinates = null, long[] mediaIds = null, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             if (status == null) throw new ArgumentNullException("status");
@@ -100,7 +100,8 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
                 {"long", geoLatLong != null ? geoLatLong.Item2 : (double?) null},
                 {"place_id", placeId},
                 {"display_coordinates", displayCoordinates},
-                {"media_ids", String.IsNullOrEmpty(mediaIdStr) ? null : mediaIdStr}
+                {"media_ids", String.IsNullOrEmpty(mediaIdStr) ? null : mediaIdStr},
+                {"tweet_mode", extendedTweet ? "extended" : null }
             }.ParametalizeForPost();
             var client = credential.CreateOAuthClient(useGZip: false);
             var response = await client.PostAsync(new ApiAccess("statuses/update.json"), param);

--- a/StarryEyes.Anomaly/TwitterApi/Rest/Tweets.cs
+++ b/StarryEyes.Anomaly/TwitterApi/Rest/Tweets.cs
@@ -70,12 +70,13 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         }
 
         public static async Task<TwitterStatus> ShowTweetAsync(
-            this IOAuthCredential credential, long id)
+            this IOAuthCredential credential, long id, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
             var param = new Dictionary<string, object>
             {
                 {"id", id},
+                {"tweet_mode", extendedTweet ? "extended" : null}
             }.ParametalizeForGet();
             var client = credential.CreateOAuthClient();
             var response = await client.GetAsync(new ApiAccess("statuses/show.json", param));
@@ -124,20 +125,26 @@ namespace StarryEyes.Anomaly.TwitterApi.Rest
         }
 
         public static async Task<TwitterStatus> DestroyAsync(
-            this IOAuthCredential credential, long id)
+            this IOAuthCredential credential, long id, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
-            var param = new Dictionary<string, object>().ParametalizeForPost();
+            var param = new Dictionary<string, object>
+            {
+                {"tweet_mode", extendedTweet ? "extended" : null}
+            }.ParametalizeForPost();
             var client = credential.CreateOAuthClient();
             var response = await client.PostAsync(new ApiAccess("statuses/destroy/" + id + ".json"), param);
             return await response.ReadAsStatusAsync();
         }
 
         public static async Task<TwitterStatus> RetweetAsync(
-            this IOAuthCredential credential, long id)
+            this IOAuthCredential credential, long id, bool extendedTweet = true)
         {
             if (credential == null) throw new ArgumentNullException("credential");
-            var param = new Dictionary<string, object>().ParametalizeForPost();
+            var param = new Dictionary<string, object>
+            {
+                {"tweet_mode", extendedTweet ? "extended" : null}
+            }.ParametalizeForPost();
             var client = credential.CreateOAuthClient();
             var response = await client.PostAsync(new ApiAccess("statuses/retweet/" + id + ".json"), param);
             return await response.ReadAsStatusAsync();

--- a/StarryEyes/Models/Subsystems/TwitterConfigurationService.cs
+++ b/StarryEyes/Models/Subsystems/TwitterConfigurationService.cs
@@ -15,7 +15,7 @@ namespace StarryEyes.Models.Subsystems
         // default values
         private static int _httpUrlLength = 22;
         private static int _httpsUrlLength = 23;
-        private static int _mediaUrlLength = 23;
+        private static int _mediaUrlLength = 0; // media url -> 0 (extended_tweet)
 
         public static int HttpUrlLength
         {

--- a/StarryEyes/StarryEyes.csproj
+++ b/StarryEyes/StarryEyes.csproj
@@ -98,7 +98,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\LivetExtensions.1.1.0.0\lib\net45\Livet.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Expression.Drawing" />
+    <Reference Include="Microsoft.Expression.Drawing, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Expression.Drawing.3.0.0\lib\net45\Microsoft.Expression.Drawing.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
       <Private>True</Private>

--- a/StarryEyes/ViewModels/WindowParts/Inputting/InputCoreViewModel.cs
+++ b/StarryEyes/ViewModels/WindowParts/Inputting/InputCoreViewModel.cs
@@ -604,6 +604,7 @@ namespace StarryEyes.ViewModels.WindowParts.Inputting
         [UsedImplicitly]
         public void AttachClipboardImage()
         {
+            if (!CanAttachImage) return;
             try
             {
                 BitmapSource image;

--- a/StarryEyes/Views/Dialogs/KeyOverrideWindow.xaml
+++ b/StarryEyes/Views/Dialogs/KeyOverrideWindow.xaml
@@ -80,7 +80,7 @@
                        Margin="8"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"
-                       TextWrapping="Wrap"><Run Language="ja-jp" Text="Consumer Sectret" />
+                       TextWrapping="Wrap"><Run Language="ja-jp" Text="Consumer Secret" />
             </TextBlock>
             <TextBox Grid.Row="0"
                      Grid.Column="1"

--- a/StarryEyes/packages.config
+++ b/StarryEyes/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Expression.Drawing" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="NAudio" version="1.7.3" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
TwitterStatusを返すRest APIを叩く時にExtended Tweetを取得するようにしました。
また，画像を添付していても140文字でツイートできるようになりました。
この変更で，Rest APIから降ってくる140文字を超えているツイートが短縮(#178)されなくなり，正常に表示されます。